### PR TITLE
Change work with orders and permissions

### DIFF
--- a/backend/cleanpro/api/permissions.py
+++ b/backend/cleanpro/api/permissions.py
@@ -18,20 +18,6 @@ class IsOwnerOrReadOnly(permissions.BasePermission):
         return request.user == obj.user or request.user.is_staff
 
 
-class IsOwner(permissions.BasePermission):
-    """
-    Предоставляет доступ:
-        - на чтение - автору объекта;
-        - на запись - автору объекта.
-    """
-
-    def has_permission(self, request, view):
-        return request.user.is_authenticated
-
-    def has_object_permission(self, request, view, obj):
-        return obj.user == request.user
-
-
 class IsAdminOrReadOnly(permissions.BasePermission):
     """
     Предоставляет доступ:
@@ -50,21 +36,28 @@ class IsAdminOrReadOnly(permissions.BasePermission):
 
 
 # TODO: убрать это. Повторяет IsOwnerOrReadOnly.
-# class IsAdminOrIsOwner(permissions.BasePermission):
-#     """
-#     Предоставляет доступ:
-#         - на запись: только администратору и автору.
-#     """
+# REPLE: Прошу не удалять. IsOwnerOrReadOnly дает право
+# анониму смотерть все заказы. Мне думается, что
+# не гоже анониму смотреть данные чужих заказов.
+# Если есть иное мнение, то я переделаю. Мне не сложно.
+class IsAdminOrIsOwner(permissions.BasePermission):
+    """
+    Предоставляет доступ:
+        - на запись: только администратору и автору.
+    """
 
-#     def has_object_permission(self, request, view, obj):
-#         return request.user == obj.user or request.user.is_staff
+    def has_permission(self, request, view):
+        return request.user.is_authenticated
+
+    def has_object_permission(self, request, view, obj):
+        return request.user == obj.user or request.user.is_staff
 
 
-# TODO: убрать это. В DRF уже встроен такой тип разрешений.
-# class IsAdminOnly(permissions.BasePermission):
-#     """
-#     Предоставляет доступ только администратору.
-#     """
+class IsNotAdmin(permissions.BasePermission):
+    """
+    Запрещает доступ администратору.
+    """
 
-#     def has_permission(self, request, view):
-#         return request.user.is_staff
+    def has_permission(self, request, view):
+        return (request.user.is_authenticated and
+                not request.user.is_staff)

--- a/backend/cleanpro/api/serializers.py
+++ b/backend/cleanpro/api/serializers.py
@@ -1,13 +1,15 @@
 import random
 import re
-from djoser.serializers import UserCreateSerializer as DjoserUserCreateSerializer # noqa (E501)
+from djoser.serializers import UserCreateSerializer as DjoserUserCreateSerializer  # noqa (E501)
 
 from django.db import transaction
 from django.db.models import QuerySet
+from django.shortcuts import get_object_or_404
 from drf_base64.fields import Base64ImageField
 from phonenumber_field.phonenumber import PhoneNumber
 from rest_framework import serializers, status
 
+from cleanpro.app_data import ORDER_CANCELLED_STATUS
 from service.models import (
     Address, CleaningType, Measure, Order, Rating, Service, ServicesInOrder
 )
@@ -205,6 +207,8 @@ class CreateCleaningTypeSerializer(serializers.ModelSerializer):
         return instance
 
     # TODO: разобраться, что тут вообще происходит.
+    # REPLE: После обновления данных в типе услуг выводятся
+    # все данные по услугам. Без этого выводятся только id каждой услуги.
     def to_representation(self, value):
         # INFO: не нужно использовать небезопасный прямой доступ по ключу.
         #       Исправил на метод .get().
@@ -257,6 +261,7 @@ class OrderGetSerializer(serializers.ModelSerializer):
             'total_sum',
             'total_time',
             'comment',
+            'comment_cancel',
             'order_status',
             'cleaning_type',
             'services',
@@ -385,7 +390,7 @@ class OrderPostSerializer(serializers.ModelSerializer):
 
     def __check_user_data(
             self, address: Address, user: User, user_data: dict
-            ) -> None: # noqa E125
+            ) -> None:  # noqa E125
         """
         Проверяет данные пользователя:
             - если отсутствует значения полей username / phone: присваиваются
@@ -460,88 +465,165 @@ class OrderPostSerializer(serializers.ModelSerializer):
         return False
 
 
-class OrderStatusSerializer(serializers.ModelSerializer):
-    """Сериализатор для изменения статуса заказа."""
+class AdminOrderPatchSerializer(serializers.ModelSerializer):
+    """Сериализатор для частичного изменения данных заказа админом."""
 
-    order_status = serializers.ChoiceField(choices=Order.STATUS_CHOICES)
+    order_status = serializers.ChoiceField(
+        choices=Order.STATUS_CHOICES,
+        required=False
+    )
+    comment_cancel = serializers.CharField(required=False)
+    pay_status = serializers.BooleanField(required=False)
+    comment = serializers.CharField(required=False)
+    cleaning_date = serializers.DateField(required=False)
+    cleaning_time = serializers.TimeField(required=False)
 
     class Meta:
         model = Order
-        fields = ('order_status',)
-
-    def update(self, instance, validated_data):
-        instance.order_status = validated_data.get(
+        fields = (
             'order_status',
-            instance.order_status,
+            'comment_cancel',
+            'pay_status',
+            'comment',
+            'cleaning_date',
+            'cleaning_time',
         )
+
+    def validate(self, data):
+        if not data:
+            raise serializers.ValidationError(
+                'Среди указанных полей нет ни '
+                'одного разрешенного для редактирования')
+        return data
+
+    def update(self, instance, validated_data):
+        if 'order_status' in validated_data.keys():
+            instance.order_status = validated_data.get(
+                'order_status',
+                instance.order_status,
+            )
+            if not instance.order_status == ORDER_CANCELLED_STATUS:
+                instance.comment_cancel = None
+        if 'comment_cancel' in validated_data.keys():
+            instance.order_status = 'cancelled'
+            instance.comment_cancel = validated_data.get(
+                'comment_cancel',
+                instance.comment_cancel
+            )
+        if 'pay_status' in validated_data.keys():
+            instance.pay_status = validated_data.get(
+                'pay_status',
+                instance.pay_status,
+            )
+        if 'comment' in validated_data.keys():
+            instance.comment = validated_data.get(
+                'comment',
+                instance.comment,
+            )
+        if 'cleaning_date' in validated_data.keys():
+            instance.cleaning_date = validated_data.get(
+                'cleaning_date',
+                instance.cleaning_date,
+            )
+        if 'cleaning_time' in validated_data.keys():
+            instance.cleaning_time = validated_data.get(
+                'cleaning_time',
+                instance.cleaning_time,
+            )
         instance.save()
         return instance
 
+    def to_representation(self, value):
+        request = self.context['request']
+        return OrderGetSerializer(
+            value,
+            context={'request': request}
+        ).data
 
-class OrderCancelSerializer(serializers.ModelSerializer):
-    """Сериализатор для отмены заказа."""
+
+class OwnerOrderPatchSerializer(serializers.ModelSerializer):
+    """Сериализатор для частичного изменения данных заказа владельцем."""
+
+    comment_cancel = serializers.CharField(required=False)
+    comment = serializers.CharField(required=False)
+    cleaning_date = serializers.DateField(required=False)
+    cleaning_time = serializers.TimeField(required=False)
 
     class Meta:
         model = Order
-        fields = ('comment_cancel',)
+        fields = (
+            'comment_cancel',
+            'comment',
+            'cleaning_date',
+            'cleaning_time',
+        )
+
+    def validate(self, data):
+        if not data:
+            raise serializers.ValidationError(
+                'Среди указанных полей нет ни '
+                'одного разрешенного для редактирования')
+        return data
 
     def update(self, instance, validated_data):
-        instance.order_status = 'cancelled'
-        instance.comment_cancel = validated_data.get(
-            'comment_cancel',
-            instance.comment_cancel
-        )
+        if 'comment_cancel' in validated_data.keys():
+            instance.order_status = 'cancelled'
+            instance.comment_cancel = validated_data.get(
+                'comment_cancel',
+                instance.comment_cancel
+            )
+        if 'comment' in validated_data.keys():
+            instance.comment = validated_data.get(
+                'comment',
+                instance.comment,
+            )
+        if 'cleaning_date' in validated_data.keys():
+            instance.cleaning_date = validated_data.get(
+                'cleaning_date',
+                instance.cleaning_date,
+            )
+        if 'cleaning_time' in validated_data.keys():
+            instance.cleaning_time = validated_data.get(
+                'cleaning_time',
+                instance.cleaning_time,
+            )
         instance.save()
         return instance
 
+    def to_representation(self, value):
+        request = self.context['request']
+        return OrderGetSerializer(
+            value,
+            context={'request': request}
+        ).data
 
-# TODO: сериализаторы не написаны с использованием DRY. Исправить.
+
 class PaySerializer(serializers.ModelSerializer):
     """Сериализатор для оплаты заказа."""
-
-    # TODO: Зачем?
-    pay_status = True
 
     class Meta:
         model = Order
         fields = ('pay_status',)
 
+    def validate(self, data):
+        print(data)
+        request = self.context['request']
+        user = request.user
+        order_id = request.data['id']
+        order = get_object_or_404(Order, id=order_id)
+        if not order.user == user:
+            raise serializers.ValidationError(
+                'Попытка оплатить чужой заказ. Оплата не возможна.')
+        if order.pay_status:
+            raise serializers.ValidationError(
+                'Заказ уже оплачен. Повторная оплата не возможна.')
+        if order.order_status == ORDER_CANCELLED_STATUS:
+            raise serializers.ValidationError(
+                'Заказ Отменен. Оплата не возможна.')
+        return data
+
     def update(self, instance, validated_data):
         instance.pay_status = True
-        instance.save()
-        return instance
-
-
-class CommentSerializer(serializers.ModelSerializer):
-    """Сериализатор для добавления комментария к заказу."""
-
-    class Meta:
-        model = Order
-        fields = ('comment',)
-
-    def update(self, instance, validated_data):
-        instance.comment = validated_data.get('comment', instance.comment)
-        instance.save()
-        return instance
-
-
-class DateTimeSerializer(serializers.ModelSerializer):
-    """Сериализатор для переноса времени заказа."""
-
-    class Meta:
-        model = Order
-        # TODO: вопрос про datetime поле все-еще активен, дублирую тут.
-        fields = ('cleaning_date', 'cleaning_time')
-
-    def update(self, instance, validated_data):
-        instance.cleaning_date = validated_data.get(
-            'cleaning_date',
-            instance.cleaning_date,
-        )
-        instance.cleaning_time = validated_data.get(
-            'cleaning_time',
-            instance.cleaning_time,
-        )
         instance.save()
         return instance
 


### PR DESCRIPTION
Patch запрос на /api/orders/{id}/pay/ на отдельный эндпоинт, доступный только владельцу заказа и с проверкой, что заказ не отменен и ранее не был оплачен. Сейчас он пока просто будет менять статус оплаты в заказе, в будущем сюда можно будет прикрутить то, что касается перехода на страницу оплаты и оформление проведения оплаты и т.д.

Patch запрос на /api/orders/{id}/ для cancel, comment, change_datetime, change_status в заказах, доступно владельцу заказа для своего заказа и админу для всех заказов. Менять за один запрос можно одно, несколько или поля все сразу.
Ниже перечень полей которые доступны админу для изменения
{
            "order_status": "finished",
            "comment_cancel": "Гала, у нас отмена",
            "pay_status": true,
            "comment": "Перенесу-ка я заказ",
            "cleaning_date": "2031-10-14",
            "cleaning_time": "16:35:00"
}

Пользователь в своем заказе может изменить только следующие поля:
{
            "comment_cancel": "Гала, у нас отмена",
            "comment": "Перенесу-ка я заказ",
            "cleaning_date": "2031-10-14",
            "cleaning_time": "16:35:00"
}